### PR TITLE
Integrate ZConfigManager

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pyZConfigManager"]
+    path = zconfigmanager
+    url = https://github.com/fieldofview/pyZConfigManager.git

--- a/zne.py
+++ b/zne.py
@@ -16,6 +16,8 @@ from qneblock import QNEBlock
 from qneport import QNEPort
 from qneconnection import QNEConnection
 
+from zconfigmanager import ZConfigManagerNode
+
 class QNEMainWindow(QMainWindow):
     def __init__(self, parent):
         super(QNEMainWindow, self).__init__(parent)

--- a/zne.py
+++ b/zne.py
@@ -58,10 +58,13 @@ class QNEMainWindow(QMainWindow):
     def installActions(self):
         quitAct = QAction("&Quit", self, shortcut="Ctrl+Q",
             statusTip="Exit the application", triggered=self.close)
-        saveAct = QAction("&Save", self, shortcut="Ctrl+S",
+        openAct = QAction("&Open...", self, shortcut="Ctrl+O",
+            statusTip="Restore the network from a saved description", triggered=self.readNetwork)
+        saveAct = QAction("&Save...", self, shortcut="Ctrl+S",
             statusTip="Write a description of the network to disc", triggered=self.writeNetwork)
 
         fileMenu = self.menuBar().addMenu("&File")
+        fileMenu.addAction(openAct)
         fileMenu.addAction(saveAct)
         fileMenu.addSeparator()
         fileMenu.addAction(quitAct)
@@ -118,19 +121,41 @@ class QNEMainWindow(QMainWindow):
 
 
     def writeNetwork(self):
-        fileName, filtr = QFileDialog.getSaveFileName(self)
+        fileName, filter = QFileDialog.getSaveFileName(self,
+                                                       caption="Save as",
+                                                       filter="ZOCP (*.zocp);;JSON (*.json)",
+                                                       selectedFilter="ZOCP (*.zocp)")
         if fileName:
             # setup ZOCP node, and run it for some time to discover
             # the current network
             configManager = ZConfigManagerNode("ConfigManager@%s" % socket.gethostname())
             configManager.discover(0.5)
-            tree = configManager.build_network_tree()
 
             # write network description to file
-            configManager.write(fileName, tree)
+            configManager.write(fileName)
 
             # shut down ZOCP node
             configManager.stop()
+            configManager = None
+
+
+    def readNetwork(self):
+        fileName, filter = QFileDialog.getOpenFileName(self,
+                                                       caption="Open",
+                                                       filter="All files (*.*);;ZOCP (*.zocp);;JSON (*.json)",
+                                                       selectedFilter="ZOCP (*.zocp)")
+        if fileName:
+            # setup ZOCP node, and run it for some time to discover
+            # the current network
+            configManager = ZConfigManagerNode("ConfigManager@%s" % socket.gethostname())
+            configManager.discover(0.5)
+
+            # write network description to file
+            configManager.read(fileName)
+
+            # shut down ZOCP node
+            configManager.stop()
+            configManager = None
 
 
     def zoomIn(self):


### PR DESCRIPTION
This pullrequest adds https://github.com/fieldofview/pyZConfigManager as a submodule. Using the Config Manager one can store and restore node configurations to/from disk. 

Node configurations consist of the full capability tree, including capability structure and data, as well as signal subscriptions between nodes. Note that ff a node has been restarted at some point, it will have a different UUID. In this case the configmanager will look for a replacement node by the same name.

pyZConfigManager can be used as a standalone command line utility, but it has been integrated in the Node Editor as Open/Save functionality.
