### PR TITLE
Integrate ZConfigManager (update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ development at z25.org. For more information see https://github.com/z25/pyZOCP
 
 Installation Notes
 ------------------
+pyZNodeEditor has a submodule for saving/loading network configurations named pyZConfigManager. Make sure the zconfigmanager folder contains the required files.
+If you are cloning a copy from git, be sure to add the --recursive option:
+```
+git clone --recursive https://github.com/z25/pyZNodeEditor.git
+```
+If you have previously checked out a copy of the editor, you can add the files by executing the following commands in the pyZNodeEditor folder:
+```
+git submodule init
+git submodule update
+```
+
 pyZNodeEditor depends on the python implementation of ZOCP. You must first install pyZOCP:
 https://github.com/z25/pyZOCP/blob/master/README.textile
 To get the pyNodeEditor up and running you need to install the following:

--- a/zne.py
+++ b/zne.py
@@ -16,7 +16,14 @@ from qneblock import QNEBlock
 from qneport import QNEPort
 from qneconnection import QNEConnection
 
-from zconfigmanager import ZConfigManagerNode
+try:
+    from zconfigmanager import ZConfigManagerNode
+    zconfigmanager_found = True
+except ImportError:
+    print ("Could not find ZConfigManagerNode class. "
+           "Load/Save functionality will not be available. Please follow "
+           "the instruction in the README to add this class.")
+    zconfigmanager_found = False
 
 class QNEMainWindow(QMainWindow):
     def __init__(self, parent):
@@ -58,15 +65,17 @@ class QNEMainWindow(QMainWindow):
     def installActions(self):
         quitAct = QAction("&Quit", self, shortcut="Ctrl+Q",
             statusTip="Exit the application", triggered=self.close)
-        openAct = QAction("&Open...", self, shortcut="Ctrl+O",
-            statusTip="Restore the network from a saved description", triggered=self.readNetwork)
-        saveAct = QAction("&Save...", self, shortcut="Ctrl+S",
-            statusTip="Write a description of the network to disc", triggered=self.writeNetwork)
+        if zconfigmanager_found:
+            openAct = QAction("&Open...", self, shortcut="Ctrl+O",
+                statusTip="Restore the network from a saved description", triggered=self.readNetwork)
+            saveAct = QAction("&Save...", self, shortcut="Ctrl+S",
+                statusTip="Write a description of the network to disc", triggered=self.writeNetwork)
 
         fileMenu = self.menuBar().addMenu("&File")
-        fileMenu.addAction(openAct)
-        fileMenu.addAction(saveAct)
-        fileMenu.addSeparator()
+        if zconfigmanager_found:
+            fileMenu.addAction(openAct)
+            fileMenu.addAction(saveAct)
+            fileMenu.addSeparator()
         fileMenu.addAction(quitAct)
 
         # for shortcuts


### PR DESCRIPTION
Update PR to this: https://github.com/z25/pyZNodeEditor/pull/6

This patch updates the README with instructions on getting the submodule. The app no longer fails to launch if the submodule is not present (instead it will be functional but the load/save functionality will be unavailable).

The patch also updates the configmanager to be more robust against multiple nodes with the same name.
