### PR TITLE
Respect r/w access

### DIFF
--- a/qneport.py
+++ b/qneport.py
@@ -87,6 +87,10 @@ class QNEPort(QGraphicsPathItem):
         self.valueText.showValue(value)
 
 
+    def setAccess(self, access):
+        self.valueText.setAccess(access)
+
+
     def setCanConnect(self, hasInput, hasOutput):
         self.hasInput_ = hasInput
         self.hasOutput_ = hasOutput

--- a/qnevalue.py
+++ b/qnevalue.py
@@ -37,8 +37,6 @@ class QNEValue(QGraphicsTextItem):
         super(QNEValue, self).__init__(parent)
 
         self.setTextWidth(-1)
-        self.setTabChangesFocus(True)
-        self.setTextInteractionFlags(Qt.TextEditorInteraction)
         self.setZValue(1)
 
         self.port = None
@@ -52,6 +50,20 @@ class QNEValue(QGraphicsTextItem):
 
     def setPort(self, port):
         self.port = port
+
+
+    def setAccess(self, access):
+        if 'r' in access:
+            self.setVisible(True)
+        else:
+            self.setVisible(False)
+
+        if 'w' in access:
+            self.setTabChangesFocus(True)
+            self.setTextInteractionFlags(Qt.TextEditorInteraction)
+        else:
+            self.setTabChangesFocus(False)
+            self.setTextInteractionFlags(Qt.NoTextInteraction)
 
 
     def port(self):

--- a/zne.py
+++ b/zne.py
@@ -339,6 +339,7 @@ class QNEMainWindow(QMainWindow):
                     hasOutput = "e" in portdata["access"]
                     port = self.nodes[peer.hex]["block"].addPort(portname, hasInput, hasOutput)
                     port.setValue(str(portdata["value"]))
+                    port.setAccess(str(portdata["access"]))
                     self.nodes[peer.hex]["ports"][portname] = port
 
                 else:
@@ -351,6 +352,8 @@ class QNEMainWindow(QMainWindow):
                 port = self.nodes[peer.hex]["ports"][portname]
                 if "value" in portdata:
                     port.setValue(str(portdata["value"]))
+                if "access" in portdata:
+                    port.setAccess(str(portdata["access"]))
 
             if "subscribers" in portdata:
                 self.updateSubscribers(port, portdata["subscribers"])


### PR DESCRIPTION
This patch makes the "ports" in de node editor respect the 'r' and 'w' settings in a parameters 'access' ("rwes"). If the access value does not include a 'w', the value is not editable in the node editor. If the access value does not include an 'r', the value is not visible.
