### PR TITLE
flipped ports at the addConnection callback

### DIFF
--- a/zne.py
+++ b/zne.py
@@ -198,10 +198,10 @@ class QNEMainWindow(QMainWindow):
         fromBlock = fromPort.block()
         toBlock = toPort.block()
 
-        emitter = toPort.portName()
-        emit_peer = toBlock.uuid()
-        receiver = fromPort.portName()
-        recv_peer = fromBlock.uuid()
+        emitter = fromPort.portName()
+        emit_peer = fromBlock.uuid()
+        receiver = toPort.portName()
+        recv_peer = toBlock.uuid()
 
         self.zocp.signal_subscribe(recv_peer, receiver, emit_peer, emitter)
 

--- a/zne.py
+++ b/zne.py
@@ -213,10 +213,10 @@ class QNEMainWindow(QMainWindow):
         fromBlock = fromPort.block()
         toBlock = toPort.block()
 
-        emitter = toPort.portName()
-        emit_peer = toBlock.uuid()
-        receiver = fromPort.portName()
-        recv_peer = fromBlock.uuid()
+        emitter = fromPort.portName()
+        emit_peer = fromBlock.uuid()
+        receiver = toPort.portName()
+        recv_peer = toBlock.uuid()
 
         self.zocp.signal_unsubscribe(recv_peer, receiver, emit_peer, emitter)
 


### PR DESCRIPTION
I'm seeing some errors during subscription through the node editor. It seems fixed by flipping the ports.
This might be due to a recent fix in ZOCP which fixed forwarding subscriptions with reversed arguments:

https://github.com/z25/pyZOCP/commit/a7ff4523ba30872bb4d2fca4934b2a526bc79d78
